### PR TITLE
added logging of unhandled exceptions in webapi

### DIFF
--- a/source/WindowsAuthentication/Configuration/LogProviderExceptionLogger.cs
+++ b/source/WindowsAuthentication/Configuration/LogProviderExceptionLogger.cs
@@ -1,0 +1,18 @@
+﻿using IdentityServer.WindowsAuthentication.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.ExceptionHandling;
+
+namespace IdentityServer.WindowsAuthentication.Configuration
+{
+    internal class LogProviderExceptionLogger : IExceptionLogger
+    {
+        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
+
+        public Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
+        {
+            Logger.ErrorException("Unhandled exception", context.Exception);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/source/WindowsAuthentication/Configuration/WindowsAuthenticationAppBuilderExtensions.cs
+++ b/source/WindowsAuthentication/Configuration/WindowsAuthenticationAppBuilderExtensions.cs
@@ -26,6 +26,7 @@ using Microsoft.Owin.Security.OAuth;
 using System;
 using System.Web.Http;
 using System.Web.Http.Dispatcher;
+using System.Web.Http.ExceptionHandling;
 
 namespace Owin
 {
@@ -54,6 +55,7 @@ namespace Owin
 
                 var webApiConfig = new HttpConfiguration();
                 webApiConfig.MapHttpAttributeRoutes();
+                webApiConfig.Services.Add(typeof(IExceptionLogger), new LogProviderExceptionLogger());
                 webApiConfig.Services.Replace(typeof(IHttpControllerTypeResolver), new ControllerResolver());
 
                 var builder = new ContainerBuilder();

--- a/source/WindowsAuthentication/WindowsAuthentication.csproj
+++ b/source/WindowsAuthentication/WindowsAuthentication.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Configuration\WindowsAuthenticationOptions.cs" />
     <Compile Include="Configuration\WindowsAuthenticationTokenProvider.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Configuration\LogProviderExceptionLogger.cs" />
     <Compile Include="ResponseGenerator\MetadataResponseGenerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResponseGenerator\MetadataResult.cs" />


### PR DESCRIPTION
should help tracking down issues in `ICustomClaimsProvider` implementations.