### PR TITLE
expires_in value doesn't show exact value

### DIFF
--- a/source/WindowsAuthentication/Configuration/WindowsAuthenticationAppBuilderExtensions.cs
+++ b/source/WindowsAuthentication/Configuration/WindowsAuthenticationAppBuilderExtensions.cs
@@ -90,7 +90,8 @@ namespace Owin
                         AllowInsecureHttp = true,
                         TokenEndpointPath = new PathString("/token"),
                         Provider = new WindowsAuthenticationTokenProvider(options),
-                        AccessTokenFormat = new JwtFormat(options)
+                        AccessTokenFormat = new JwtFormat(options),
+                        AccessTokenExpireTimeSpan = TimeSpan.FromMinutes(options.TokenLifeTime)
                     });
             }
 


### PR DESCRIPTION
AccessTokenExpireTimeSpan is needs to be set.

Real Token lifetime is correct but when we get token response. "expires_in" value is wrong in json response.